### PR TITLE
syncronizationFixForWaitingToBorrowObject

### DIFF
--- a/ObjectPool.package/OPBasicPool.class/instance/ensureMinimumIdleObjects.st
+++ b/ObjectPool.package/OPBasicPool.class/instance/ensureMinimumIdleObjects.st
@@ -1,3 +1,3 @@
-as yet unclassified
+pooling
 ensureMinimumIdleObjects
 	self critical: [ self whileNotEnoughIdleObjects: [ self addObject ] ]

--- a/ObjectPool.package/OPBasicPool.class/instance/fixMaxActiveObjects.st
+++ b/ObjectPool.package/OPBasicPool.class/instance/fixMaxActiveObjects.st
@@ -1,4 +1,4 @@
-as yet unclassified
+pooling
 fixMaxActiveObjects
 
 	self critical: [maxActiveObjects := self numberOfAvailableObjects].

--- a/ObjectPool.package/OPBasicPool.class/instance/hasEnoughIdleObjects.st
+++ b/ObjectPool.package/OPBasicPool.class/instance/hasEnoughIdleObjects.st
@@ -1,3 +1,3 @@
-as yet unclassified
+pooling
 hasEnoughIdleObjects
 	^ minIdleObjects ifNil: [ true ] ifNotNil: [ idleObjects size >= minIdleObjects ]

--- a/ObjectPool.package/OPBasicPool.class/instance/ifNotEnoughIdleObjects..st
+++ b/ObjectPool.package/OPBasicPool.class/instance/ifNotEnoughIdleObjects..st
@@ -1,3 +1,3 @@
-as yet unclassified
+pooling
 ifNotEnoughIdleObjects: aBlock
 	^ self hasEnoughIdleObjects ifTrue: aBlock

--- a/ObjectPool.package/OPBasicPool.class/instance/migrateObjectsInto.andDo..st
+++ b/ObjectPool.package/OPBasicPool.class/instance/migrateObjectsInto.andDo..st
@@ -1,8 +1,8 @@
-as yet unclassified
+pooling
 migrateObjectsInto: anotherPool andDo: aBlock
 
 	self critical: [ 
-		borrowedObjects ifNotEmpty: [ self error: 'Pool allow migration only when al objects are free' ].
+		borrowedObjects ifNotEmpty: [ self error: 'Pool allow migration only when all objects are free' ].
 		
 		idleObjects do: [ :each | 
 			anotherPool objectToPool: each.

--- a/ObjectPool.package/OPBasicPool.class/instance/objectForBorrow.st
+++ b/ObjectPool.package/OPBasicPool.class/instance/objectForBorrow.st
@@ -1,9 +1,0 @@
-pooling
-objectForBorrow
-	^self critical: [ 
-		maxActiveObjects
-			ifNotNil: [ 
-				maxWaitForBorrow
-					ifNil: [ self waitUntil: [ self numberOfActiveObjects < maxActiveObjects ] ]
-					ifNotNil: [ self waitUntil: [ self numberOfActiveObjects < maxActiveObjects ] timoutAfterMilliseconds: maxWaitForBorrow ] ].
-		super objectForBorrow	]

--- a/ObjectPool.package/OPBasicPool.class/instance/objectForBorrow.st
+++ b/ObjectPool.package/OPBasicPool.class/instance/objectForBorrow.st
@@ -1,11 +1,9 @@
-as yet unclassified
+pooling
 objectForBorrow
-	self critical: [ 
-	maxActiveObjects
-		ifNotNil: [ 
-			maxWaitForBorrow
-				ifNil: [ self waitUntil: [ self numberOfActiveObjects < maxActiveObjects ] ]
-				ifNotNil: [ self waitUntil: [ self numberOfActiveObjects < maxActiveObjects ] timoutAfterMilliseconds: maxWaitForBorrow ] ].
-	].
-	
-	^ super objectForBorrow
+	^self critical: [ 
+		maxActiveObjects
+			ifNotNil: [ 
+				maxWaitForBorrow
+					ifNil: [ self waitUntil: [ self numberOfActiveObjects < maxActiveObjects ] ]
+					ifNotNil: [ self waitUntil: [ self numberOfActiveObjects < maxActiveObjects ] timoutAfterMilliseconds: maxWaitForBorrow ] ].
+		super objectForBorrow	]

--- a/ObjectPool.package/OPBasicPool.class/instance/unsafeBorrow.st
+++ b/ObjectPool.package/OPBasicPool.class/instance/unsafeBorrow.st
@@ -1,0 +1,13 @@
+pooling
+unsafeBorrow
+	| newObject |
+	self critical: [ 
+		maxActiveObjects ifNotNil: [ 
+			maxWaitForBorrow
+				ifNil: [ self waitUntil: [ self numberOfActiveObjects < maxActiveObjects ] ]
+				ifNotNil: [ self waitUntil: [ self numberOfActiveObjects < maxActiveObjects ] timoutAfterMilliseconds: maxWaitForBorrow ]].
+		idleObjects ifNotEmpty: [ 
+			^ borrowedObjects add: self objectFromPool ]	].
+	newObject := self makeObject.
+	self critical: [borrowedObjects add: newObject].
+	^newObject

--- a/ObjectPool.package/OPBasicPool.class/instance/whileNotEnoughIdleObjects..st
+++ b/ObjectPool.package/OPBasicPool.class/instance/whileNotEnoughIdleObjects..st
@@ -1,3 +1,3 @@
-as yet unclassified
+pooling
 whileNotEnoughIdleObjects: aBlock
 	^ [self hasEnoughIdleObjects] whileFalse: aBlock.

--- a/ObjectPool.package/OPBasicPool.class/properties.json
+++ b/ObjectPool.package/OPBasicPool.class/properties.json
@@ -11,8 +11,6 @@
 		"activator",
 		"destroyer",
 		"validator",
-		"maxWait",
-		"maxActive",
 		"minIdleObjects",
 		"maxIdleObjects",
 		"maxActiveObjects",

--- a/ObjectPool.package/OPPool.class/instance/borrow.st
+++ b/ObjectPool.package/OPPool.class/instance/borrow.st
@@ -3,12 +3,11 @@ borrow
 	"Returns activated object from pool or creates new pooled object and returns it."
 
 	| object |
-	[ 
-	object := self objectForBorrow.
-	self objectGoingToBeBorrowed: object.
-	self critical: [borrowedObjects add: object] ]
+	[ object := self unsafeBorrow.
+	self objectGoingToBeBorrowed: object]
 		on: OPAbortOperation
 		do: [ :e | 
+			self critical: [borrowedObjects remove: object].
 			self destroyObject: object.
 			e retry ].
 	^ object

--- a/ObjectPool.package/OPPool.class/instance/objectForBorrow.st
+++ b/ObjectPool.package/OPPool.class/instance/objectForBorrow.st
@@ -1,3 +1,0 @@
-private
-objectForBorrow
-	^self objectFromPoolOrElse: [ self makeObject ]

--- a/ObjectPool.package/OPPool.class/instance/return..st
+++ b/ObjectPool.package/OPPool.class/instance/return..st
@@ -3,12 +3,13 @@ return: anObject
 	"Returns previously borrowed object from the pool. If object is not from this pool then
 	ObjectPoolWrongPoolError is raised."
 
-	self
-		critical: [ 
-			(borrowedObjects includes: anObject)
-				ifTrue: [ borrowedObjects remove: anObject ]
-				ifFalse: [ OPWrongPoolError signal: 'Object is not from this pool instance.' ] ].
-	[ 
-	self objectGoingToBeReturned: anObject.
-	self objectToPool: anObject.
-	] on: OPAbortOperation do: [ self destroyObject: anObject. ].
+	self critical: [ 
+		(borrowedObjects includes: anObject)
+			ifFalse: [ OPWrongPoolError signal: 'Object is not from this pool instance.' ]].
+	
+	[self objectGoingToBeReturned: anObject] on: OPAbortOperation do: [ 
+		^self destroyObject: anObject].
+	
+	self critical: [
+		borrowedObjects remove: anObject.
+		self objectToPool: anObject]

--- a/ObjectPool.package/OPPool.class/instance/unsafeBorrow.st
+++ b/ObjectPool.package/OPPool.class/instance/unsafeBorrow.st
@@ -1,0 +1,6 @@
+private
+unsafeBorrow
+	| object |
+	object := self objectFromPoolOrElse: [ self makeObject ].
+	self critical: [borrowedObjects add: object].
+	^object


### PR DESCRIPTION
Seems I finaly found the real bug which lead to the case when passive pool (without creator) was tried to create object instead of waiting on monitor.
Problem that accessing idle object was done out of critical section which perform wait for next free object. So it waits when free object is appeared but then it exit monitor which allow other thread to break established condition and borrow detected object