### PR TITLE
Pharo 8 improvements

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+*.st linguist-language=Smalltalk

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,26 @@
+name: Build
+
+on:
+  pull_request:
+  push:
+
+jobs:
+   build:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        smalltalk: [ Pharo64-8.0, Pharo64-7.0, Pharo32-7.0 ]
+    name: ${{ matrix.smalltalk }}
+    steps:
+      - uses: actions/checkout@v2
+      - uses: hpi-swa/setup-smalltalkCI@v1
+        with:
+          smalltalk-version: ${{ matrix.smalltalk }}
+      - run: smalltalkci -s ${{ matrix.smalltalk }}
+        timeout-minutes: 15
+      - run: echo "::set-env name=SCI_COVERAGE_FILE_LOCATION::${HOME}/.smalltalkCI/_builds/coveralls_results.json"
+      - name: Upload coverage to Codecov
+        uses: codecov/codecov-action@v1.0.6
+        with:
+          token: ${{ secrets.CODECOV_TOKEN }}
+          file: ${{ env.SCI_COVERAGE_FILE_LOCATION }}

--- a/.project
+++ b/.project
@@ -1,0 +1,3 @@
+{
+	'srcDirectory' : ''
+}

--- a/.smalltalk.ston
+++ b/.smalltalk.ston
@@ -1,0 +1,17 @@
+SmalltalkCISpec {
+  #loading : [
+    SCIMetacelloLoadSpec {
+      #baseline : 'ObjectPool',
+      #directory : '',
+      #load : [ 'Tests' ],
+      #platforms : [  #pharo ]
+    }
+  ],
+  #testing : {
+    #coverage : {
+       #packages : [ 'ObjectPool*' ],
+       #service: #codecov,
+       #auto_upload: false
+    }
+  }
+}

--- a/README.md
+++ b/README.md
@@ -1,4 +1,11 @@
 # ObjectPool
+
+[![GitHub release](https://img.shields.io/github/release/pharo-ide/ObjectPool.svg)](https://github.com/pharo-ide/ObjectPool/releases/latest)
+[![Build Status](https://github.com/pharo-ide/ObjectPool/workflows/Build/badge.svg?branch=master)](https://github.com/pharo-ide/ObjectPool/actions?query=workflow%3ABuild)
+[![Coverage Status](https://codecov.io/github/pharo-ide/ObjectPool/coverage.svg?branch=master)](https://codecov.io/gh/pharo-ide/ObjectPool/branch/master)
+[![Pharo 7.0](https://img.shields.io/badge/Pharo-7.0-informational)](https://pharo.org)
+[![Pharo 8.0](https://img.shields.io/badge/Pharo-8.0-informational)](https://pharo.org)
+
 Object Pool offers easy way to build pools for objects. One common situation
 could be pooling database connections. This library was created for supporting pooling
 of GlorpDBX database connections. However GlorpDBX related code is different
@@ -19,11 +26,11 @@ OPBasicPool new
 To get new collection from the pool:
 ```Smalltalk
 pool withPooled: [:o| "Do something"].
-```	
+```
 To also clear collections when they are returned add passivator
 ```Smalltalk
 pool passivator:[:o|o removeAll].
-```	
+```
 Or to do that before borrow add activator:
 ```Smalltalk
 pool activator:[:o|o removeAll].
@@ -48,4 +55,3 @@ spec
     baseline: 'ObjectPool'
     with: [ spec repository: 'github://pharo-ide/ObjectPool:v1.0.0' ]
 ```
-


### PR DESCRIPTION
- Add `.project` so the repo will load cleanly on Pharo > 8
- Add a build using GitHub Actions
- Add coverage reporting by CodeCov, you will need to login to https://codecov.io, allow the repository access and configure as a secret in the repository `CODECOV_TOKEN` with the token provided by codecov.
- Add some hints in `.gitattributes` so GitHub can detect correctly the language

If you need some help setting up codecov just let me know.