### PR TITLE
Pharo 10

### DIFF
--- a/.github/workflows/loading-groups.yml
+++ b/.github/workflows/loading-groups.yml
@@ -8,7 +8,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        smalltalk: [ Pharo64-9.0, Pharo64-8.0 ]
+        smalltalk: [ Pharo64-10, Pharo64-9.0, Pharo64-8.0 ]
         load-spec: [ core, tests ]
     name: ${{ matrix.smalltalk }} + ${{ matrix.load-spec }}
     steps:

--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -7,7 +7,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        smalltalk: [ Pharo64-9.0, Pharo64-8.0, Pharo64-7.0, Pharo32-7.0 ]
+        smalltalk: [ Pharo64-10, Pharo64-9.0, Pharo64-8.0, Pharo64-7.0, Pharo32-7.0 ]
     name: ${{ matrix.smalltalk }}
     steps:
       - uses: actions/checkout@v2

--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) 2017-2021 Denis Kudriashov
+Copyright (c) 2017-2022 Denis Kudriashov
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/ObjectPool-Tests/OPBasicPoolTest.class.st
+++ b/ObjectPool-Tests/OPBasicPoolTest.class.st
@@ -4,7 +4,7 @@ ObjectPoolTest tests the working of ObjectPool.
 Class {
 	#name : #OPBasicPoolTest,
 	#superclass : #OPPoolTestCase,
-	#category : 'ObjectPool-Tests'
+	#category : #'ObjectPool-Tests'
 }
 
 { #category : #running }
@@ -153,18 +153,21 @@ OPBasicPoolTest >> testMigrationObjectsToAnotherPool [
 OPBasicPoolTest >> testMigrationObjectsToAnotherPoolWhenBorrowedObjectsExists [
 
 	| anotherPool |
+
 	pool objectToPool: #object1.
 	pool objectToPool: #object2.
 	pool borrow.
-	
+
 	anotherPool := self poolClass new.
-	
-	[pool migrateObjectsInto: anotherPool andDo: nil.
-	self assert: false description: 'should raise error'
-	] ifError: [].
-		
-	self assert: anotherPool numberOfAvailableObjects = 0.
-	self assert: pool numberOfAvailableObjects = 2
+
+	self
+		should: [ 
+			pool migrateObjectsInto: anotherPool andDo: nil.
+			self assert: false description: 'should raise error'
+			]
+		raise: Error.
+	self assert: anotherPool numberOfAvailableObjects equals: 0.
+	self assert: pool numberOfAvailableObjects equals: 2
 ]
 
 { #category : #tests }

--- a/README.md
+++ b/README.md
@@ -8,6 +8,7 @@
 [![Pharo 7.0](https://img.shields.io/badge/Pharo-7.0-informational)](https://pharo.org)
 [![Pharo 8.0](https://img.shields.io/badge/Pharo-8.0-informational)](https://pharo.org)
 [![Pharo 9.0](https://img.shields.io/badge/Pharo-9.0-informational)](https://pharo.org)
+[![Pharo 10](https://img.shields.io/badge/Pharo-10-informational)](https://pharo.org)
 
 Object Pool offers easy way to build pools for objects. One common situation
 could be pooling database connections. This library was created for supporting pooling


### PR DESCRIPTION
- Add Pharo 10 to build matrix
- Fix test failing on Pharo 10 because blocks no longer understand `ifError:`